### PR TITLE
feat: Integrate symbolic cache tier system into MoEOrchestrator

### DIFF
--- a/src/cache_tier.rs
+++ b/src/cache_tier.rs
@@ -1,0 +1,138 @@
+// src/cache_tier.rs
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheTier {
+    L1,
+    L2,
+    L3,
+    RAM,
+}
+
+pub trait ExpertTagged {
+    fn cache_tier(&self) -> CacheTier;
+}
+
+// Import Expert trait for type constraint in filter_experts_by_tier
+use crate::moe::Expert;
+
+pub fn filter_experts_by_tier(
+    indexed_scores: &[(usize, f32)],
+    all_experts: &[Box<dyn Expert>],
+    allowed_tiers: &[CacheTier],
+) -> Vec<(usize, f32)> {
+    if allowed_tiers.is_empty() {
+        return Vec::new();
+    }
+
+    let mut filtered_experts = Vec::new();
+
+    for &(expert_original_index, score) in indexed_scores {
+        if expert_original_index < all_experts.len() {
+            let expert = &all_experts[expert_original_index];
+            if allowed_tiers.contains(&expert.cache_tier()) {
+                filtered_experts.push((expert_original_index, score));
+            }
+        } else {
+            eprintln!(
+                "Warning: Expert index {} out of bounds (total experts: {}). Skipping.",
+                expert_original_index,
+                all_experts.len()
+            );
+        }
+    }
+    filtered_experts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // Assuming MLPExpert and SymbolicExpert are accessible for testing via crate::moe
+    // and implement Expert + ExpertTagged.
+    // Their `new` methods also need to be public.
+    use crate::moe::{Expert, MLPExpert, SymbolicExpert}; 
+
+
+    #[test]
+    fn test_filter_single_allowed_tier_l1() {
+        let experts: Vec<Box<dyn Expert>> = vec![
+            Box::new(SymbolicExpert::new("SymL1", 0.5)), // L1
+            Box::new(MLPExpert::new("MlpL2")),          // L2
+        ];
+        let indexed_scores = vec![(0, 0.6), (1, 0.4)];
+        let allowed_tiers = [CacheTier::L1];
+
+        let filtered = filter_experts_by_tier(&indexed_scores, &experts, &allowed_tiers);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0], (0, 0.6)); // Only SymbolicExpert (index 0)
+    }
+
+    #[test]
+    fn test_filter_multiple_allowed_tiers_l1_l2() {
+        let experts: Vec<Box<dyn Expert>> = vec![
+            Box::new(SymbolicExpert::new("SymL1", 0.5)), // L1 (idx 0)
+            Box::new(MLPExpert::new("MlpL2")),          // L2 (idx 1)
+        ];
+        let indexed_scores = vec![(0, 0.6), (1, 0.4)];
+        let allowed_tiers = [CacheTier::L1, CacheTier::L2];
+
+        let filtered = filter_experts_by_tier(&indexed_scores, &experts, &allowed_tiers);
+        assert_eq!(filtered.len(), 2);
+        assert!(filtered.contains(&(0, 0.6)));
+        assert!(filtered.contains(&(1, 0.4)));
+    }
+
+    #[test]
+    fn test_filter_no_experts_match() {
+        let experts: Vec<Box<dyn Expert>> = vec![
+            Box::new(SymbolicExpert::new("SymL1", 0.5)), // L1
+            Box::new(MLPExpert::new("MlpL2")),          // L2
+        ];
+        let indexed_scores = vec![(0, 0.6), (1, 0.4)];
+        let allowed_tiers = [CacheTier::L3]; // No L3 experts defined
+
+        let filtered = filter_experts_by_tier(&indexed_scores, &experts, &allowed_tiers);
+        assert_eq!(filtered.len(), 0);
+    }
+
+    #[test]
+    fn test_filter_allowed_tiers_is_empty() {
+        let experts: Vec<Box<dyn Expert>> = vec![
+            Box::new(SymbolicExpert::new("SymL1", 0.5)),
+            Box::new(MLPExpert::new("MlpL2")),
+        ];
+        let indexed_scores = vec![(0, 0.6), (1, 0.4)];
+        let allowed_tiers = []; // Empty allowed tiers
+
+        let filtered = filter_experts_by_tier(&indexed_scores, &experts, &allowed_tiers);
+        assert_eq!(filtered.len(), 0);
+    }
+
+    #[test]
+    fn test_filter_indexed_scores_is_empty() {
+        let experts: Vec<Box<dyn Expert>> = vec![
+            Box::new(SymbolicExpert::new("SymL1", 0.5)),
+            Box::new(MLPExpert::new("MlpL2")),
+        ];
+        let indexed_scores = []; // Empty scores
+        let allowed_tiers = [CacheTier::L1, CacheTier::L2];
+
+        let filtered = filter_experts_by_tier(&indexed_scores, &experts, &allowed_tiers);
+        assert_eq!(filtered.len(), 0);
+    }
+    
+    #[test]
+    fn test_filter_out_of_bounds_index_ignored() {
+        let experts: Vec<Box<dyn Expert>> = vec![
+            Box::new(SymbolicExpert::new("SymL1", 0.5)), // Index 0, L1
+            Box::new(MLPExpert::new("MlpL2")),          // Index 1, L2
+        ];
+        let indexed_scores = vec![(0, 0.5), (1, 0.3), (2, 0.2)]; 
+        let allowed_tiers = [CacheTier::L1, CacheTier::L2];
+
+        let filtered = filter_experts_by_tier(&indexed_scores, &experts, &allowed_tiers);
+        
+        assert_eq!(filtered.len(), 2);
+        assert!(filtered.contains(&(0, 0.5))); 
+        assert!(filtered.contains(&(1, 0.3))); 
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ use std::io::Read; // For load_pre_tokenized_from_json
 pub mod config;
 pub mod common;
 pub mod attention;
+pub mod cache_tier;
 pub mod mlp;
 pub mod model;
 pub mod tokenizer {

--- a/src/moe.rs
+++ b/src/moe.rs
@@ -1,8 +1,9 @@
 use ndarray::{ArrayD, Array1, Axis}; // Added Axis
 use crate::gating::GatingLayer; // Import GatingLayer
+use crate::cache_tier::{CacheTier, ExpertTagged};
 
 // Define the Expert trait
-pub trait Expert: std::fmt::Debug { // Added Debug for easy printing of Box<dyn Expert>
+pub trait Expert: std::fmt::Debug + ExpertTagged { // Added Debug for easy printing of Box<dyn Expert> and ExpertTagged as supertrait
     fn name(&self) -> String;
     // Input: The input tensor for the expert to process.
     // theta_hat: The current intentionality score.
@@ -35,6 +36,12 @@ impl Expert for MLPExpert {
         // let output = input.mapv(|x| x + 0.1); 
         // Ok(output)
         Ok(input.clone()) // Simple pass-through for now
+    }
+}
+
+impl ExpertTagged for MLPExpert {
+    fn cache_tier(&self) -> CacheTier {
+        CacheTier::L2
     }
 }
 
@@ -72,6 +79,12 @@ impl Expert for SymbolicExpert {
             output = output.mapv(|x| x + 0.01); // Default small shift
         }
         Ok(output)
+    }
+}
+
+impl ExpertTagged for SymbolicExpert {
+    fn cache_tier(&self) -> CacheTier {
+        CacheTier::L1
     }
 }
 


### PR DESCRIPTION
This commit introduces a symbolic cache tiering system for experts (L1, L2, L3, RAM) and integrates it into the `MoEOrchestrator`.

Key changes:
- Added `src/cache_tier.rs` defining `CacheTier` enum, `ExpertTagged` trait, and `filter_experts_by_tier` function.
- Modified `src/moe.rs`:
    - `Expert` trait now requires `ExpertTagged` as a supertrait.
    - `MLPExpert` and `SymbolicExpert` implement `ExpertTagged` (as L2 and L1 respectively).
- Modified `src/orchestrator.rs`:
    - `MoEOrchestrator` now has a `current_allowed_tiers` field to control which expert tiers can be activated.
    - `determine_active_experts` method now filters experts based on this policy before applying other selection logic (e.g., resource limits, top-K).
    - The `current_allowed_tiers` is initialized to allow all tiers; dynamic adjustment based on system load is a future enhancement.
- Added unit tests for `filter_experts_by_tier` in `src/cache_tier.rs`.
- Added unit tests for `MoEOrchestrator` in `src/orchestrator.rs` to verify the correct application of cache tier policies.

This system allows `MoEOrchestrator` to make more nuanced decisions about expert activation, enabling strategies like prioritizing L1 experts during high system load, as outlined in the initial issue.