### PR TITLE
Add comparative analysis of Rust prototype vs. Python Transformers.

### DIFF
--- a/PYTHON_VS_RUST_GPT2_COMPARISON.md
+++ b/PYTHON_VS_RUST_GPT2_COMPARISON.md
@@ -1,0 +1,117 @@
+# Comparison: Rust Native Transformer vs. Python (Hugging Face) Transformers for GPT-2
+
+This document compares a local Rust-based GPT-2 prototype (`rust-native-transformer`) with the widely-used Python Hugging Face `transformers` library, focusing on their GPT-2 implementations.
+
+## 1. Design Philosophy
+
+### Rust Native Transformer
+- **Goal:** Pure Rust implementation, built from scratch.
+- **Emphasis:** Transparency, introspection, computational sovereignty (independence from non-Rust ecosystems).
+- **Approach:** Minimal dependencies, native Rust for core components (tokenizer, tensor ops, model).
+
+### Hugging Face Python `transformers`
+- **Goal:** Provide a comprehensive library of pre-trained models for various tasks, easy to use and adapt.
+- **Emphasis:** Usability, accessibility, vast model support, interoperability between frameworks (PyTorch, TensorFlow, JAX).
+- **Approach:** Python frontend with heavy reliance on underlying DL frameworks (PyTorch/TF/JAX) and their optimized C++/CUDA backends. Extensive use of the Hugging Face Hub.
+
+## 2. Core Features
+
+| Feature                 | Rust Native Transformer (`rust-native-transformer`) | Hugging Face `transformers` (Python GPT-2) |
+|-------------------------|---------------------------------------------------|--------------------------------------------|
+| **Model Architecture**  | Custom GPT-2 (MHA, FFN, Blocks)                   | Standard GPT-2, various sizes (gpt2, gpt2-xl, etc.) |
+| **Underlying Tensors**  | Custom `Tensor<f32>` from `tensor_engine.rs`      | PyTorch Tensors, TensorFlow Tensors, JAX arrays |
+| **Tensor Operations**   | Basic native ops (matmul, softmax, layernorm, gelu in `transformer_core.rs` via `tensor_engine.rs`). No SIMD/batching mentioned as optimized yet. | Highly optimized via backends (CUDA, MKL, etc.) |
+| **Weight Loading**      | `.safetensors` via custom `model_loader.rs`. Handles HF naming (e.g. `c_attn` split). | Multiple formats, primarily from Hub. `.safetensors` well-supported. |
+| **Tokenization**        | Native BPE (`tokenizer_core.rs`). GPT-2 style ("Ġ" prefix). | `GPT2Tokenizer` (Python) & `GPT2TokenizerFast` (Rust-backed via `tokenizers` lib). BPE, handles "Ġ" / `add_prefix_space`. |
+| **KV Caching**          | Implemented (`ModelKVCache` in `transformer_core.rs`). Structure: `Vec<Vec<KVCacheEntry>>` (per layer, per head). | Yes (`past_key_values`). Advanced Cache objects and legacy tuple format. Essential for generation. |
+| **Generation Strategy** | Greedy decoding (`text_generator.rs`). Notes plans for Top-K/Top-P. | Supports greedy, beam search, sampling (Top-K, Top-P, etc.) via `generate()` method. |
+| **Supported Tasks**     | Primarily text generation (CLI).                  | Text generation, classification, QA, etc., with different model heads. |
+| **Pre-trained Models**  | Requires user to provide model weights.           | Large selection available from Hugging Face Hub. |
+| **Multi-framework**     | Rust only.                                        | PyTorch, TensorFlow, JAX.                  |
+| **Quantization**        | Not mentioned.                                    | Yes (e.g., bitsandbytes for 4-bit, 8-bit). |
+| **Special Features**    | `theta_hat` for "Resonance Feedback" in attention. | Training stability options (Mistral-inspired), head pruning, etc. |
+
+## 3. Ease of Use
+
+### Rust Native Transformer
+- **Interface:** Command-Line Interface (CLI) via `runtime_interface.rs`.
+- **Setup:** Requires Rust/Cargo. Build from source. User must provide model/tokenizer files and config parameters.
+- **Learning Curve:** Steeper for non-Rust developers or those unfamiliar with compiling projects. Understanding the "from scratch" nature requires deeper model knowledge.
+
+### Hugging Face Python `transformers`
+- **Interface:** Python API (e.g., `AutoModel.from_pretrained()`, `pipeline()`). Also `transformers-cli`.
+- **Setup:** `pip install transformers`. Models downloadable from Hub.
+- **Learning Curve:** Generally easier, especially for Python developers. High-level APIs abstract many details. Extensive examples and tutorials.
+
+## 4. Extensibility and Modularity
+
+### Rust Native Transformer
+- **Modularity:** Code is organized into modules (tokenizer, tensor engine, model core, etc.).
+- **Extensibility:** Being pure Rust and from scratch, it's highly modifiable if one understands the Rust codebase. Adding new tensor ops or model layers requires direct Rust implementation.
+- **Limitations:** Smaller ecosystem, fewer off-the-shelf components to integrate compared to Python.
+
+### Hugging Face Python `transformers`
+- **Modularity:** Well-defined classes for models, configs, tokenizers. Clear separation of concerns.
+- **Extensibility:** Highly extensible. Easy to derive custom models, add new heads, or integrate with other Python libraries. Callbacks for training.
+- **Ecosystem:** Benefits from the vast Python ML ecosystem (scikit-learn, PyTorch Lightning, etc.).
+
+## 5. Theoretical Benchmark Discussion
+
+*No actual benchmarks were run. This is a conceptual discussion.*
+
+### Rust Native Transformer
+- **Potential Advantages:**
+    - Compiled language (Rust) can offer lower overhead than interpreted Python.
+    - Direct memory management in Rust *could* lead to more optimized memory use if implemented carefully.
+    - No Python Global Interpreter Lock (GIL) limitations for true parallelism (if Rust code is structured for it).
+- **Current Stated Limitations / Considerations:**
+    - `tensor_engine.rs` is described as basic in its README, lacking SIMD or advanced batching optimizations. This would be a major performance bottleneck compared to optimized libraries.
+    - Tokenizer has some known issues with complex inputs, which might affect practical throughput.
+    - KV cache is implemented, which is good, but its performance relative to highly optimized versions is unknown.
+
+### Hugging Face Python `transformers`
+- **Advantages:**
+    - Relies on highly optimized backends (PyTorch, TensorFlow, JAX) that use C++/CUDA for core computations (matmul, convolutions etc.). These are state-of-the-art in terms of performance.
+    - `GPT2TokenizerFast` (Rust-backed) is very performant.
+    - Supports features like FlashAttention / SDPA (Scaled Dot Product Attention) for optimized attention computations.
+    - Mature KV cache implementations.
+    - Supports various quantization techniques (e.g., `bitsandbytes`) for faster inference and lower memory, especially on compatible hardware.
+- **Considerations:**
+    - Python overhead exists, but it's often minimized for heavy computations by deferring to C++/CUDA backends.
+    - Inter-op between Python and backends can add some overhead, though usually minor for large workloads.
+
+**Overall Theoretical Expectation:** For raw numerical performance on standard hardware (especially GPUs), the Hugging Face `transformers` library is expected to be significantly faster and more optimized due to its reliance on mature deep learning frameworks and their C++/CUDA backends, as well as features like `FlashAttention` and quantization. The Rust prototype *could* be very performant if its `tensor_engine` were to be heavily optimized (e.g., with SIMD, custom CUDA kernels if targeting GPUs), but its current description suggests it's not at that stage.
+
+## 6. Dependencies
+
+### Rust Native Transformer
+- **Core:** Pure Rust, `cargo` for build.
+- **Notable Crates mentioned/implied:** `clap` (for CLI args), `serde_json` (for vocab). Minimal external dependencies for core logic.
+
+### Hugging Face Python `transformers`
+- **Core:** Python.
+- **Frameworks:** PyTorch, TensorFlow, or JAX (at least one required for model execution).
+- **Key Libraries:** `safetensors`, `huggingface_hub`, `tokenizers` (Rust library), `numpy`.
+- **Optional:** `bitsandbytes` (for quantization), `accelerate` (for distributed training/inference), many others.
+
+## 7. Documentation and Community Support
+
+### Rust Native Transformer
+- **Documentation:** Primarily README files (`README.md`, `rust-native-transformer/README.md`), code comments. As a local prototype, it lacks extensive external documentation.
+- **Community:** Specific to this project (likely small, internal). No broad community like established open-source projects.
+
+### Hugging Face Python `transformers`
+- **Documentation:** Extremely comprehensive official documentation (concepts, API docs, tutorials, examples).
+- **Community:** Very large and active (GitHub issues, forums, Discord, model contributions on the Hub). Vast amount of community-generated content (blog posts, tutorials, example projects).
+
+## 8. Conclusion
+
+The **`rust-native-transformer`** project serves as an excellent educational tool and a demonstration of building a transformer model from scratch in pure Rust. Its strengths lie in its transparency, minimal dependencies for core logic, and potential for deep customization by Rust developers. It successfully implements core GPT-2 functionalities including native BPE tokenization and KV caching. However, as acknowledged in its READMEs, its current tensor operations are basic and not yet optimized for high performance comparable to established DL frameworks.
+
+The **Hugging Face Python `transformers`** library, on the other hand, is a mature, feature-rich, and highly optimized library designed for ease of use and broad applicability. It provides access to a vast array of pre-trained models (including many GPT-2 variants), supports multiple ML frameworks, and benefits from a large ecosystem and community. Its performance is generally state-of-the-art due to its reliance on optimized backends and features like "fast" tokenizers and quantization.
+
+**In summary:**
+- **Choose `rust-native-transformer` for:** Understanding transformer internals, learning pure Rust ML implementation, research requiring deep modification of a from-scratch Rust model, or projects prioritizing Rust-only environments with minimal external non-Rust dependencies for the core model logic.
+- **Choose Hugging Face `transformers` for:** Production use cases, rapid prototyping, access to a wide variety of pre-trained models, leveraging highly optimized performance (especially on GPUs), ease of use for common NLP tasks, and strong community/ecosystem support.
+
+The comparison highlights different design goals: the Rust project aims for a self-contained, understandable Rust implementation, while Hugging Face aims for a versatile, high-performance, and user-friendly gateway to many transformer models.


### PR DESCRIPTION
This commit introduces a new markdown document, PYTHON_VS_RUST_GPT2_COMPARISON.md, which provides a detailed comparison between the local `rust-native-transformer` prototype and the Hugging Face Python `transformers` library, focusing on their respective GPT-2 implementations.

The analysis covers several aspects:
- Design Philosophy
- Core Features (model architecture, tensor operations, tokenization, KV caching, etc.)
- Ease of Use (API, setup, learning curve)
- Extensibility and Modularity
- Theoretical Benchmark Discussion (conceptual performance differences)
- Dependencies
- Documentation and Community Support
- Conclusion summarizing the strengths and typical use cases for each.

This document aims to clarify the differences and help you decide which approach might be better suited for different needs when working with GPT-2 models.