### PR TITLE
Fix GPT2Model helper comment

### DIFF
--- a/src/ndarray_specific/model.rs
+++ b/src/ndarray_specific/model.rs
@@ -363,13 +363,9 @@ mod tests {
         TransformerBlock::new(config).expect("Failed to create TransformerBlock for testing")
     }
 
-    // Helper to create GPT2Model for testing
-    // Note: GPT2Model::new now requires wte_data and wpe_data.
-    // We need to provide dummy data for these.
+    // Helper to create GPT2Model for testing using the default constructor
     fn test_gpt2_model(config: &GPT2Config) -> GPT2Model {
-        let wte_data = vec![0.0f32; (config.vocab_size * config.n_embd) as usize];
-        let wpe_data = vec![0.0f32; (config.n_positions * config.n_embd) as usize];
-        GPT2Model::new(config, &wte_data, &wpe_data).expect("Failed to create GPT2Model for testing")
+        GPT2Model::new(config).expect("Failed to create GPT2Model for testing")
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- update outdated comment about `GPT2Model::new`
- use default constructor in tests

## Testing
- `cargo test --features ndarray_backend` *(fails: could not compile `rust_transformers_gpt2`)*

------
https://chatgpt.com/codex/tasks/task_e_683f6da7f7a0832d8633fa6e08873e01