### PR TITLE
feat: Optimize Transformer with SIMD and Rayon parallelism

### DIFF
--- a/rust-native-transformer/Cargo.toml
+++ b/rust-native-transformer/Cargo.toml
@@ -11,6 +11,7 @@ serde_json = "1.0"
 clap = { version = "4.4", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.8", features = ["v4", "serde"] }
+rayon = "1.8"
 
 [dev-dependencies]
 tempfile = "3.10" 


### PR DESCRIPTION
This commit introduces significant performance enhancements to the Transformer model by leveraging SIMD intrinsics for tensor operations and Rayon for parallel computation in the Multi-Head Attention mechanism.

**1. SIMD Optimizations in `tensor_engine.rs` (AVX2 + FMA):**

- **`gelu`:** Implemented an AVX2-accelerated GELU function using a polynomial approximation for `tanhf`. Includes runtime feature detection and scalar fallback.
- **`layernorm`:** Implemented AVX2-accelerated Layer Normalization. SIMD is applied to calculate mean, variance, and the final normalization, scaling, and shifting per slice. Includes runtime feature detection and scalar fallback.
- **`matmul`:** Implemented AVX2-accelerated 2D matrix multiplication. Uses FMA intrinsics. Elements from matrix B are gathered manually; transposition of B is noted as a future optimization. Includes runtime detection and scalar fallback.
- **`softmax`:** Implemented AVX2-accelerated Softmax. Uses a Taylor series approximation for `expf` and SIMD for max value calculation, sums, and divisions per slice. Includes runtime detection and scalar fallback.
- Helper functions for horizontal sum (`horizontal_sum_m256`) and horizontal max (`horizontal_max_m256`) for `__m256` vectors were added.

**2. Rayon Parallelism in `transformer_core.rs` (`MultiHeadAttention`):**

- Added `rayon = "1.8"` as a dependency.
- **KV Cache Update:** Refactored to be parallelism-friendly. New K/V tensors for each head are computed in parallel (reading from a snapshot of the previous state) and then the main cache is updated sequentially from these results.
- **Attention Score Calculation:** The loops over batches and heads for computing `Q @ K_t` and scaling are now parallelized using Rayon.
- **Output Combination:** The loops over batches and heads for computing `AttnProbs @ V` are now parallelized using Rayon.
- Error handling in parallelized loops is managed by collecting `Result` types.
- Final assembly of tensors from parallelized parts remains sequential.

These changes aim to improve the inference speed of the `rust-native-transformer` on compatible hardware by making better use of both single-core SIMD capabilities and multi-core parallelism.