### PR TITLE
Add simple training support

### DIFF
--- a/rust-native-transformer/src/lib.rs
+++ b/rust-native-transformer/src/lib.rs
@@ -6,3 +6,4 @@ pub mod transformer_core;
 pub mod text_generator;
 pub mod runtime_interface;
 pub mod resonance_feedback;
+pub mod training;

--- a/rust-native-transformer/src/runtime_interface.rs
+++ b/rust-native-transformer/src/runtime_interface.rs
@@ -8,6 +8,7 @@ use crate::tensor_engine; // Not directly used here, but good to have if errors 
 use crate::text_generator;
 use crate::tokenizer_core;
 use crate::transformer_core;
+use crate::training;
 // use crate::resonance_feedback::{ResonanceFeedbackStore, ExperienceEntry, ValidationStatus}; // Added
 // use uuid; // Added for direct UUID usage if ExperienceEntry::new() doesn't set it (it does)
 
@@ -28,6 +29,9 @@ struct CliArgs {
     max_length: usize,
     #[clap(long, value_parser, default_value_t = 50256)] // Default EOS for GPT-2
     eos_token_id: u32,
+
+    #[clap(long, value_parser, default_value = "inference")]
+    mode: String,
 
     // Model Configuration Arguments
     #[clap(long, value_parser, default_value_t = 12)]
@@ -133,7 +137,7 @@ pub fn run_cli() -> Result<(), Box<dyn Error>> {
     };
     println!("Model configuration prepared: {:?}", config);
 
-    let model = transformer_core::GPT2Model::new(config, weights_map).map_err(RuntimeError::from)?;
+    let mut model = transformer_core::GPT2Model::new(config, weights_map).map_err(RuntimeError::from)?;
     println!("GPT-2 Model instantiated.");
 
     // 4. Tokenize Prompt
@@ -153,15 +157,25 @@ pub fn run_cli() -> Result<(), Box<dyn Error>> {
     }
     println!("Prompt token IDs: {:?}", input_ids);
     
+    if args.mode.to_lowercase() == "training" {
+        let mut targets = input_ids[1..].to_vec();
+        targets.push(args.eos_token_id);
+        let input_tensor = tensor_engine::Tensor::new(input_ids.clone(), vec![1, input_ids.len()])?;
+        let target_tensor = tensor_engine::Tensor::new(targets, vec![1, input_tensor.shape[1]])?;
+        let optimizer = training::SGDOptimizer { learning_rate: 0.001 };
+        let loss = training::train_step(&mut model, &input_tensor, &target_tensor, &optimizer).map_err(RuntimeError::from)?;
+        println!("Training step completed. Loss: {}", loss);
+        return Ok(());
+    }
+
     // 5. Generate Text
     println!("Generating text (max_length: {}, eos_token_id: {})...", args.max_length, args.eos_token_id);
     let generated_ids = text_generator::generate(
-        &model, 
-        input_ids.clone(), 
-        args.max_length, 
+        &model,
+        input_ids.clone(),
+        args.max_length,
         args.eos_token_id,
         None
-        // Some(&feedback_store) // Pass the feedback store
     ).map_err(RuntimeError::from)?;
     println!("Generated token IDs: {:?}", generated_ids);
 

--- a/rust-native-transformer/src/training.rs
+++ b/rust-native-transformer/src/training.rs
@@ -1,0 +1,87 @@
+use crate::tensor_engine::{Tensor, TensorError};
+use crate::transformer_core::{GPT2Model, TransformerError};
+
+/// Simple stochastic gradient descent optimizer
+pub struct SGDOptimizer {
+    pub learning_rate: f32,
+}
+
+impl SGDOptimizer {
+    pub fn apply(&self, param: &mut [f32], grad: &[f32]) {
+        for (p, g) in param.iter_mut().zip(grad.iter()) {
+            *p -= self.learning_rate * g;
+        }
+    }
+}
+
+/// Compute cross entropy loss between `logits` and `targets`.
+/// `logits` shape: [B, S, V], `targets` shape: [B, S]
+pub fn cross_entropy_loss(logits: &Tensor<f32>, targets: &Tensor<u32>) -> Result<f32, TensorError> {
+    let probs = logits.softmax(logits.rank() - 1)?;
+    let batch = targets.shape[0];
+    let seq = targets.shape[1];
+    let vocab = logits.shape[2];
+    let mut loss = 0.0f32;
+    for b in 0..batch {
+        for s in 0..seq {
+            let t = targets.data[b * seq + s] as usize;
+            let idx = b * seq * vocab + s * vocab + t;
+            let p = probs.data[idx].max(1e-12); // avoid log(0)
+            loss -= p.ln();
+        }
+    }
+    loss /= (batch * seq) as f32;
+    Ok(loss)
+}
+
+/// Compute gradient of cross entropy with respect to logits
+fn cross_entropy_grad(logits: &Tensor<f32>, targets: &Tensor<u32>) -> Result<Tensor<f32>, TensorError> {
+    let probs = logits.softmax(logits.rank() - 1)?;
+    let mut grad = probs.data.clone();
+    let batch = targets.shape[0];
+    let seq = targets.shape[1];
+    let vocab = logits.shape[2];
+    for b in 0..batch {
+        for s in 0..seq {
+            let t = targets.data[b * seq + s] as usize;
+            let idx = b * seq * vocab + s * vocab + t;
+            grad[idx] -= 1.0;
+        }
+    }
+    Tensor::new(grad, logits.shape.clone())
+}
+
+/// Perform a single training step updating the model's embedding matrix
+pub fn train_step(
+    model: &mut GPT2Model,
+    input_ids: &Tensor<u32>,
+    target_ids: &Tensor<u32>,
+    optimizer: &SGDOptimizer,
+) -> Result<f32, TransformerError> {
+    // forward pass and capture hidden states
+    let (logits, hidden) = model.forward_with_hidden(input_ids, None, None, None)?;
+    let loss = cross_entropy_loss(&logits, target_ids)?;
+    let grad_logits = cross_entropy_grad(&logits, target_ids)?;
+
+    // compute gradient for wte
+    let batch = input_ids.shape[0];
+    let seq = input_ids.shape[1];
+    let emb = hidden.shape[2];
+    let vocab = logits.shape[2];
+    let mut grad_wte = vec![0f32; vocab * emb];
+    for b in 0..batch {
+        for s in 0..seq {
+            for v in 0..vocab {
+                let gl = grad_logits.data[b * seq * vocab + s * vocab + v];
+                if gl == 0.0 { continue; }
+                for e in 0..emb {
+                    let h = hidden.data[b * seq * emb + s * emb + e];
+                    grad_wte[v * emb + e] += h * gl;
+                }
+            }
+        }
+    }
+
+    model.apply_wte_gradient(&grad_wte, optimizer.learning_rate);
+    Ok(loss)
+}


### PR DESCRIPTION
## Summary
- implement `training.rs` with cross entropy loss and SGD optimizer
- add `forward_with_hidden` and weight update helper in `transformer_core`
- expose new `mode` CLI option in `runtime_interface`
- register new module in library

## Testing
- `cargo check` in `rust-native-transformer`
- `cargo test` in `rust-native-transformer`

------
https://chatgpt.com/codex/tasks/task_e_684111b87e0c832d93f59f485dd530a3